### PR TITLE
fix '汁'

### DIFF
--- a/Xdi8Translator/data.py
+++ b/Xdi8Translator/data.py
@@ -8179,7 +8179,7 @@ hanzi2xdi8_dict={
     '时': 'HoH', 
     '莳': 'Hoy', 
     '十': 'Huo', 
-    '汁': 'HEuo', 
+    '汁': 'EHuo', 
     '什': 'VHuo', 
     '针': 'NHuo', 
     '叶': 'diey', 


### PR DESCRIPTION
在核查“不能出现元音+介音+元音”时发现，违反规则的只有这一个字