### PR TITLE
fix '窠'

### DIFF
--- a/Xdi8Translator/data.py
+++ b/Xdi8Translator/data.py
@@ -3078,7 +3078,7 @@ hanzi2xdi8_dict={
     '锞': 'kieN', 
     '稞': 'kieh', 
     '髁': 'kiej', 
-    '窠': 'kiuf', 
+    '窠': 'kief', 
     '堁': 'kied', 
     '敤': 'kie7', 
     '戏': 'kE', 


### PR DESCRIPTION
在核查“不能出现介音+介音”时发现。违反规则的还有一个字“誓”sii，但它实际上是正确的